### PR TITLE
move serve logic outside of constructor

### DIFF
--- a/examples/echo/echo.go
+++ b/examples/echo/echo.go
@@ -152,6 +152,11 @@ func main() {
 	// Register our echoer GRPC service.
 	echosvc.RegisterEchoServiceServer(grpcProto.GetGRPCServer(), &Echoer{PeerID: ha.ID()})
 
+	// start accepting the connections
+	go func() {
+		log.Fatalln(grpcProto.Serve())
+	}()
+
 	if *target == "" {
 		log.Println("listening for connections")
 		select {} // hang forever

--- a/p2pgrpc.go
+++ b/p2pgrpc.go
@@ -31,14 +31,18 @@ func NewGRPCProtocol(ctx context.Context, host host.Host) *GRPCProtocol {
 		streamCh:   make(chan inet.Stream),
 	}
 	host.SetStreamHandler(Protocol, grpcProtocol.HandleStream)
-	// Serve will not return until Accept fails, when the ctx is canceled.
-	go grpcServer.Serve(newGrpcListener(grpcProtocol))
 	return grpcProtocol
 }
 
 // GetGRPCServer returns the grpc server.
 func (p *GRPCProtocol) GetGRPCServer() *grpc.Server {
 	return p.grpcServer
+}
+
+// Serve initiates the grpc server to accept new connections
+// Note: should be called after registering the server and handlers
+func (p *GRPCProtocol) Serve() error {
+	return p.grpcServer.Serve(newGrpcListener(p))
 }
 
 // HandleStream handles an incoming stream.


### PR DESCRIPTION
`NewGRPCProtocol` calls `grpcServer.Serve` in a go routine.
Since the server and handler registrations are called after the `NewGRPCProtocol`. The registration of handler gives out this error `grpc: Server.RegisterService after Server.Serve`

Added a `Serve` method to `GRPCProtocol` which calls `grpcServer.Serve` so that it can be called after the registration 